### PR TITLE
Add additional params for EtchSigner, more example documentation

### DIFF
--- a/examples/create_etch_existing_cast.py
+++ b/examples/create_etch_existing_cast.py
@@ -54,7 +54,20 @@ def main():
         # send emails when this etch packet is created.
         # It can also be set to "embedded" which will _not_ send emails, and
         # you will need to handle sending the signer URLs manually in some way.
-        signer_type="embedded",
+        signer_type="email",
+        # You can also change how signatures will be collected.
+        # "draw" will allow the signer to draw their signature
+        # "text" will insert a text version of the signer's name into the
+        # signature field.
+        signature_mode="draw",
+        # Whether or not to the signer is required to click each signature
+        # field manually. If `False`, the PDF will be signed once the signer
+        # accepts the PDF without making the user go through the PDF.
+        accept_each_field=False,
+        # URL of where the signer will be redirected after signing.
+        # The URL will also have certain URL params added on, so the page
+        # can be customized based on the signing action.
+        redirect_url="https://www.google.com"
     )
 
     # Add your signer.

--- a/python_anvil/api.py
+++ b/python_anvil/api.py
@@ -231,7 +231,7 @@ class Anvil:
                 "`payload` must be a valid CreateEtchPacket instance or dict"
             )
         return self.mutate(
-            mutation, variables=mutation.create_payload().dict(by_alias=True), **kwargs
+            mutation, variables=mutation.create_payload().dict(by_alias=True, exclude_none=True), **kwargs
         )
 
     def generate_etch_signing_url(self, signer_eid: str, client_user_id: str, **kwargs):

--- a/python_anvil/api_resources/payload.py
+++ b/python_anvil/api_resources/payload.py
@@ -6,6 +6,7 @@ import re
 # import `BaseModel` and it's not broken, so let's keep it.
 from pydantic import (  # pylint: disable=no-name-in-module
     BaseModel as _BaseModel,
+    Field,
     validator,
 )
 from typing import Any, Dict, List, Literal, Optional, Union
@@ -89,9 +90,15 @@ class EtchSigner(BaseModel):
     email: str
     fields: List[SignerField]
     signer_type: str = "email"
-    # Will be generated if `None`
-    id: Optional[str] = ""
+    # id will be generated if `None`
+    id: Optional[str] = None
     routing_order: Optional[int] = None
+    redirect_url: Optional[str] = Field(None, alias="redirectURL")
+    # acceptEachField, signatureMode
+    accept_each_field: Optional[bool] = None
+    enable_emails: Optional[List[str]] = None
+    # signature_mode can be "draw" or "text" (default: text)
+    signature_mode: Optional[str] = None
 
 
 class SignatureField(BaseModel):


### PR DESCRIPTION
Support additional params on `EtchSigner` to keep in parity with updated official docs and the Node library.