### PR TITLE
Support webhookURL, extra fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 1.1.0 (2021-11-15)
+
+- Added support for `webhook_url` on Etch packets. Please see the `CreateEtchPacketPayload` class
+  and [Anvil API docs](https://www.useanvil.com/docs/api/e-signatures#webhook-notifications) for more info.
+- Better support for extra (unsupported) fields in all models. Previously fields not defined in models would be
+  stripped, or would raise a runtime error. Additional fields will no longer be stripped and will be used in JSON
+  payloads as you may expect. Note that, though this is now supported, the Anvil API will return an error for any
+  unsupported fields.
+- Updated documentation.
+
 # 1.0.0 (2021-10-14)
 
 - **[BREAKING CHANGE]** `dataclasses-json` library removed and replaced

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -45,10 +45,36 @@ signer1 = EtchSigner(
     name="Jackie",
     email="jackie@example.com",
     # Fields where the signer needs to sign
+    # Check your cast fields via the CLI (`anvil cast [cast_eid]`) or the
+    # PDF Templates section on the Anvil app.
+    # This basically says: "In the 'introPages' file (defined as
+    # `pdf_template` above), assign the signature field with cast id of
+    # 'def456' to this signer." You can add multiple signer fields here.
     fields=[SignerField(
         file_id="fileAlias",
         field_id="signOne",
-    )]
+    )],
+    # By default, `signer_type` will be "email" which will automatically
+    # send emails when this etch packet is created.
+    # It can also be set to "embedded" which will _not_ send emails, and
+    # you will need to handle sending the signer URLs manually in some way.
+    signer_type="email",
+    #
+    # You can also change how signatures will be collected.
+    # "draw" will allow the signer to draw their signature
+    # "text" will insert a text version of the signer's name into the
+    # signature field.
+    signature_mode="draw",
+    #
+    # Whether or not to the signer is required to click each signature
+    # field manually. If `False`, the PDF will be signed once the signer
+    # accepts the PDF without making the user go through the PDF.
+    accept_each_field=False,
+    #
+    # URL of where the signer will be redirected after signing.
+    # The URL will also have certain URL params added on, so the page
+    # can be customized based on the signing action.
+    redirect_url="https://app.useanvil.com",
 )
 
 # Add your signer. This could also be done when the `Anvil` class is
@@ -72,7 +98,8 @@ file1 = DocumentUpload(
     )]
 )
 
-# You can also reference an existing PDF template.
+# You can reference an existing PDF Template from your Anvil account
+# instead of uploading a new file.
 # You can find this information by going to the "PDF Templates" section of
 # your Anvil account, choosing a template, and selecting "API Info" at the
 # top-right of the page.
@@ -82,6 +109,7 @@ file1 = DocumentUpload(
 # template.
 file2 = EtchCastRef(
     # The `id` here is what should be used by signer objects above.
+    # This can be any string, but should be unique if adding multiple files.
     id="fileAlias",
     # The eid of the cast you want to use from "API Info" or through the CLI
     cast_eid="CAST_EID_GOES_HERE"

--- a/docs/api_usage.md
+++ b/docs/api_usage.md
@@ -153,10 +153,10 @@ for more details the creation process.
 
 ### Data Types
 
-This package uses `dataclass_json` heavily to serialize and validate data.
+This package uses `pydantic` heavily to serialize and validate data.
 These dataclasses exist in `python_anvil/api_resources/payload.py`.
 
-Please see [dataclass_json's docs](https://lidatong.github.io/dataclasses-json/) for more details on how to use these
+Please see [pydantic's docs](https://pydantic-docs.helpmanual.io/) for more details on how to use these
 dataclass instances.
 
 
@@ -184,4 +184,28 @@ headers = res["headers"]
 
 # No headers
 res = anvil.fill_pdf("some_template_id", payload, include_headers=False)
+```
+
+### Using fields that are not yet supported
+
+There may be times when the Anvil API has new features or options, but explicit support hasn't yet been added to this
+library. As of version 1.1 of `python-anvil`, extra fields are supported on all model objects.
+
+For example:
+
+```python
+from python_anvil.api_resources.payload import EtchSigner, SignerField
+
+# Use `EtchSigner`
+signer = EtchSigner(
+  name="Taylor Doe",
+  email="tdoe@example.com",
+  fields=[SignerField(file_id="file1", field_id="sig1")]
+)
+
+# Previously, adding this next field would raise an error, or would be removed from the resulting JSON payload, but this
+# is now supported.
+# NOTE: the field name should be the _exact_ field name needed in JSON. This will usually be camel-case (myVariable) and
+# not the typical PEP 8 standard snake case (my_variable).
+signer.newFeature = True
 ```

--- a/examples/create_etch_existing_cast.py
+++ b/examples/create_etch_existing_cast.py
@@ -17,6 +17,11 @@ def main():
     packet = CreateEtchPacket(
         name="Etch packet with existing template",
         signature_email_subject="Please sign these forms",
+        # URL where Anvil will send POST requests when server events happen.
+        # Take a look at https://www.useanvil.com/docs/api/e-signatures#webhook-notifications
+        # for other details on how to configure webhooks on your account.
+        # You can also use sites like webhook.site, requestbin.com or ngrok to test webhooks.
+        # webhook_url="https://my.webhook.example.com/etch-events/
     )
 
     # You can reference an existing PDF Template from your Anvil account
@@ -55,19 +60,22 @@ def main():
         # It can also be set to "embedded" which will _not_ send emails, and
         # you will need to handle sending the signer URLs manually in some way.
         signer_type="email",
+        #
         # You can also change how signatures will be collected.
         # "draw" will allow the signer to draw their signature
         # "text" will insert a text version of the signer's name into the
         # signature field.
-        signature_mode="draw",
+        # signature_mode="draw",
+        #
         # Whether or not to the signer is required to click each signature
         # field manually. If `False`, the PDF will be signed once the signer
         # accepts the PDF without making the user go through the PDF.
-        accept_each_field=False,
+        # accept_each_field=False,
+        #
         # URL of where the signer will be redirected after signing.
         # The URL will also have certain URL params added on, so the page
         # can be customized based on the signing action.
-        redirect_url="https://www.google.com",
+        # redirect_url="https://www.google.com",
     )
 
     # Add your signer.

--- a/examples/create_etch_existing_cast.py
+++ b/examples/create_etch_existing_cast.py
@@ -47,9 +47,11 @@ def main():
         name="Morgan",
         email="morgan@example.com",
         # Fields where the signer needs to sign.
+        # Check your cast fields via the CLI (`anvil cast [cast_eid]`) or the
+        # PDF Templates section on the Anvil app.
         # This basically says: "In the 'introPages' file (defined as
         # `pdf_template` above), assign the signature field with cast id of
-        # "def456" to this signer. You can add multiple signer fields here.
+        # 'def456' to this signer." You can add multiple signer fields here.
         fields=[
             SignerField(
                 file_id="introPages",
@@ -85,7 +87,14 @@ def main():
     # Add your file(s)
     packet.add_file(pdf_template)
 
+    # If needed, you can also override or add additional payload fields this way.
+    # This is useful if the Anvil API has new features, but `python-anvil` has not
+    # yet been updated to support it.
+    # payload = packet.create_payload()
+    # payload.aNewFeature = True
+
     # Create your packet
+    # If overriding/adding new fields, use the modified payload from `packet.create_payload()`
     res = anvil.create_etch_packet(payload=packet)
     print(res)
 

--- a/examples/create_etch_existing_cast.py
+++ b/examples/create_etch_existing_cast.py
@@ -20,7 +20,8 @@ def main():
         # URL where Anvil will send POST requests when server events happen.
         # Take a look at https://www.useanvil.com/docs/api/e-signatures#webhook-notifications
         # for other details on how to configure webhooks on your account.
-        # You can also use sites like webhook.site, requestbin.com or ngrok to test webhooks.
+        # You can also use sites like webhook.site, requestbin.com or ngrok to
+        # test webhooks.
         # webhook_url="https://my.webhook.example.com/etch-events/
     )
 

--- a/examples/create_etch_existing_cast.py
+++ b/examples/create_etch_existing_cast.py
@@ -94,7 +94,8 @@ def main():
     # payload.aNewFeature = True
 
     # Create your packet
-    # If overriding/adding new fields, use the modified payload from `packet.create_payload()`
+    # If overriding/adding new fields, use the modified payload from
+    # `packet.create_payload()`
     res = anvil.create_etch_packet(payload=packet)
     print(res)
 

--- a/examples/create_etch_upload_file.py
+++ b/examples/create_etch_upload_file.py
@@ -119,7 +119,8 @@ def main():
     # payload.aNewFeature = True
 
     # Create your packet
-    # If overriding/adding new fields, use the modified payload from `packet.create_payload()`
+    # If overriding/adding new fields, use the modified payload from
+    # `packet.create_payload()`
     res = anvil.create_etch_packet(payload=packet, include_headers=True)
     print(res)
 

--- a/examples/create_etch_upload_file.py
+++ b/examples/create_etch_upload_file.py
@@ -28,7 +28,8 @@ def main():
         # URL where Anvil will send POST requests when server events happen.
         # Take a look at https://www.useanvil.com/docs/api/e-signatures#webhook-notifications
         # for other details on how to configure webhooks on your account.
-        # You can also use sites like webhook.site, requestbin.com or ngrok to test webhooks.
+        # You can also use sites like webhook.site, requestbin.com or ngrok to
+        # test webhooks.
         # webhook_url="https://my.webhook.example.com/etch-events/
     )
 

--- a/examples/create_etch_upload_file.py
+++ b/examples/create_etch_upload_file.py
@@ -25,6 +25,11 @@ def main():
     packet = CreateEtchPacket(
         name="Etch packet with uploaded file",
         signature_email_subject="Please sign these forms",
+        # URL where Anvil will send POST requests when server events happen.
+        # Take a look at https://www.useanvil.com/docs/api/e-signatures#webhook-notifications
+        # for other details on how to configure webhooks on your account.
+        # You can also use sites like webhook.site, requestbin.com or ngrok to test webhooks.
+        # webhook_url="https://my.webhook.example.com/etch-events/
     )
 
     # Get your file(s) ready to sign.
@@ -79,6 +84,22 @@ def main():
             )
         ],
         signer_type="embedded",
+        #
+        # You can also change how signatures will be collected.
+        # "draw" will allow the signer to draw their signature
+        # "text" will insert a text version of the signer's name into the
+        # signature field.
+        # signature_mode="draw",
+        #
+        # Whether or not to the signer is required to click each signature
+        # field manually. If `False`, the PDF will be signed once the signer
+        # accepts the PDF without making the user go through the PDF.
+        # accept_each_field=False,
+        #
+        # URL of where the signer will be redirected after signing.
+        # The URL will also have certain URL params added on, so the page
+        # can be customized based on the signing action.
+        # redirect_url="https://www.google.com",
     )
 
     # Add your signer.

--- a/examples/create_etch_upload_file.py
+++ b/examples/create_etch_upload_file.py
@@ -76,6 +76,9 @@ def main():
         # Fields where the signer needs to sign.
         # Check your cast fields via the CLI (`anvil cast [cast_eid]`) or the
         # PDF Templates section on the Anvil app.
+        # This basically says: "In the 'myNewFile' file (defined in
+        # `file1` above), assign the signature field with cast id of
+        # 'sign1' to this signer." You can add multiple signer fields here.
         fields=[
             SignerField(
                 # this is the `id` in the `DocumentUpload` object above
@@ -109,6 +112,14 @@ def main():
     # Add files to your payload
     packet.add_file(file1)
 
+    # If needed, you can also override or add additional payload fields this way.
+    # This is useful if the Anvil API has new features, but `python-anvil` has not
+    # yet been updated to support it.
+    # payload = packet.create_payload()
+    # payload.aNewFeature = True
+
+    # Create your packet
+    # If overriding/adding new fields, use the modified payload from `packet.create_payload()`
     res = anvil.create_etch_packet(payload=packet, include_headers=True)
     print(res)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 
 name = "python_anvil"
-version = "1.0.0"
+version = "1.1.0"
 description = "Anvil API"
 
 license = "MIT"

--- a/python_anvil/api_resources/mutations/create_etch_packet.py
+++ b/python_anvil/api_resources/mutations/create_etch_packet.py
@@ -187,7 +187,7 @@ class CreateEtchPacket(BaseQuery):
                 )
         return self.file_payloads
 
-    def create_payload(self):
+    def create_payload(self) -> CreateEtchPacketPayload:
         """Create a payload based on data set on the class instance.
 
         Check `api_resources.payload.CreateEtchPacketPayload` for full payload

--- a/python_anvil/api_resources/mutations/create_etch_packet.py
+++ b/python_anvil/api_resources/mutations/create_etch_packet.py
@@ -85,6 +85,7 @@ class CreateEtchPacket(BaseQuery):
         is_draft: bool = False,
         is_test: bool = True,
         payload: Optional[CreateEtchPacketPayload] = None,
+        webhook_url: Optional[str] = None,
     ):
         # name and signature_email_subject are required when payload
         # is not present.
@@ -103,6 +104,7 @@ class CreateEtchPacket(BaseQuery):
         self.is_draft = is_draft
         self.is_test = is_test
         self.payload = payload
+        self.webhook_url = webhook_url
 
     @classmethod
     def create_from_dict(cls, payload: dict):
@@ -206,4 +208,5 @@ class CreateEtchPacket(BaseQuery):
             data=CreateEtchFilePayload(payloads=self.get_file_payloads()),
             signature_email_subject=self.signature_email_subject,
             signature_page_options=self.signature_page_options or {},
+            webhook_url=self.webhook_url,
         )

--- a/python_anvil/api_resources/payload.py
+++ b/python_anvil/api_resources/payload.py
@@ -153,3 +153,4 @@ class CreateEtchPacketPayload(BaseModel):
     is_test: Optional[bool] = True
     data: Optional[CreateEtchFilePayload] = None
     signature_page_options: Optional[Dict[Any, Any]] = None
+    webhook_url: Optional[str] = Field(None, alias="webhookURL")

--- a/python_anvil/api_resources/payload.py
+++ b/python_anvil/api_resources/payload.py
@@ -6,9 +6,9 @@ import re
 # import `BaseModel` and it's not broken, so let's keep it.
 from pydantic import (  # pylint: disable=no-name-in-module
     BaseModel as _BaseModel,
+    Extra,
     Field,
     validator,
-    Extra,
 )
 from typing import Any, Dict, List, Literal, Optional, Union
 

--- a/python_anvil/api_resources/payload.py
+++ b/python_anvil/api_resources/payload.py
@@ -8,6 +8,7 @@ from pydantic import (  # pylint: disable=no-name-in-module
     BaseModel as _BaseModel,
     Field,
     validator,
+    Extra,
 )
 from typing import Any, Dict, List, Literal, Optional, Union
 
@@ -29,6 +30,11 @@ class BaseModel(_BaseModel):
 
         alias_generator = underscore_to_camel
         allow_population_by_field_name = True
+
+        # Allow extra fields even if it is not defined. This will allow models
+        # to be more flexible if features are added in the Anvil API, but
+        # explicit support hasn't been added yet to this library.
+        extra = Extra.allow
 
 
 class EmbeddedLogo(BaseModel):

--- a/python_anvil/tests/test_api.py
+++ b/python_anvil/tests/test_api.py
@@ -236,10 +236,12 @@ def describe_api():
         @mock.patch('python_anvil.api.GraphqlRequest.post')
         def test_create_etch_packet_json(m_request_post, m_create_unique, anvil):
             m_create_unique.return_value = "signer-mock-generated"
-            anvil.create_etch_packet(
-                json=json.dumps(payloads.EXPECTED_ETCH_TEST_PAYLOAD_JSON)
-            )
+            # We are currently removing `None`s from the payload, so do that here too.
+            payload = {
+                k: v
+                for k, v in payloads.EXPECTED_ETCH_TEST_PAYLOAD_JSON.items()
+                if v is not None
+            }
+            anvil.create_etch_packet(json=json.dumps(payload))
             assert m_request_post.call_count == 1
-            assert (
-                payloads.EXPECTED_ETCH_TEST_PAYLOAD_JSON in m_request_post.call_args[0]
-            )
+            assert payload in m_request_post.call_args[0]


### PR DESCRIPTION
* Adds explicit support for `webhookURL` in the `CreateEtchPacket` mutation. (#21)
* Add documentation and support for extra fields on all models 