### PR TITLE
Bump mkdocs version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-mkdocs==1.2.2; python_version >= "3.6"
+mkdocs==1.2.3; python_version >= "3.6"
 pygments==2.10.0; python_version >= "3.5"

--- a/poetry.lock
+++ b/poetry.lock
@@ -474,7 +474,7 @@ python-versions = ">=3.6,<4.0"
 
 [[package]]
 name = "mkdocs"
-version = "1.2.2"
+version = "1.2.3"
 description = "Project documentation with Markdown."
 category = "dev"
 optional = false
@@ -1127,7 +1127,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.2"
-content-hash = "9a76bc6ebe346fa06d6815d155478e63b9cd42b2696fc1c53642f9acf343894b"
+content-hash = "71b9cd05e6afe5fb4c20ba933dd3dfce942b5460d5e7ad34d635d62325a08ff7"
 
 [metadata.files]
 altgraph = [
@@ -1392,8 +1392,8 @@ minilog = [
     {file = "minilog-2.0.1.tar.gz", hash = "sha256:52cbec563f266f1e931fd884edbb53a87ce24817365d84cc9dc628a96ea00b85"},
 ]
 mkdocs = [
-    {file = "mkdocs-1.2.2-py3-none-any.whl", hash = "sha256:d019ff8e17ec746afeb54eb9eb4112b5e959597aebc971da46a5c9486137f0ff"},
-    {file = "mkdocs-1.2.2.tar.gz", hash = "sha256:a334f5bd98ec960638511366eb8c5abc9c99b9083a0ed2401d8791b112d6b078"},
+    {file = "mkdocs-1.2.3-py3-none-any.whl", hash = "sha256:a1fa8c2d0c1305d7fc2b9d9f607c71778572a8b110fb26642aa00296c9e6d072"},
+    {file = "mkdocs-1.2.3.tar.gz", hash = "sha256:89f5a094764381cda656af4298727c9f53dc3e602983087e1fe96ea1df24f4c1"},
 ]
 mypy = [
     {file = "mypy-0.910-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:a155d80ea6cee511a3694b108c4494a39f42de11ee4e61e72bc424c490e46457"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ freezegun = "*"
 coveragespace = {git = "https://github.com/jacebrowning/coverage-space-cli.git", rev = "c167484787a223227b1ad5393300f8ca2bafe7a2"}
 
 # Documentation
-mkdocs = "1.2.2"
+mkdocs = "1.2.3"
 pygments = "^2.5.2"
 
 # Tooling


### PR DESCRIPTION
Bump `mkdocs` package version to take care of: https://github.com/advisories/GHSA-qh9q-34h6-hcv9