### PR TITLE
Fix for is_test and is_draft not being properly passed to mutation

### DIFF
--- a/python_anvil/api_resources/mutations/create_etch_packet.py
+++ b/python_anvil/api_resources/mutations/create_etch_packet.py
@@ -202,6 +202,8 @@ class CreateEtchPacket(BaseQuery):
             raise TypeError("`name` and `signature_email_subject` cannot be None")
 
         return CreateEtchPacketPayload(
+            is_test=self.is_test,
+            is_draft=self.is_draft,
             name=self.name,
             signers=self.signers,
             files=self.files,

--- a/python_anvil/tests/test_api.py
+++ b/python_anvil/tests/test_api.py
@@ -212,6 +212,22 @@ def describe_api():
             assert expected_data in m_request_post.call_args[0]
 
         @mock.patch('python_anvil.api.GraphqlRequest.post')
+        def test_create_etch_packet_passes_options(m_request_post, anvil):
+            payload = CreateEtchPacket(
+                is_test=False,
+                is_draft=True,
+                name="Packet name",
+                signature_email_subject="The subject",
+            )
+            new_expected = dict(**expected_data)
+            new_expected["isTest"] = False
+            new_expected["isDraft"] = True
+            anvil.create_etch_packet(payload)
+
+            assert m_request_post.call_count == 1
+            assert new_expected in m_request_post.call_args[0]
+
+        @mock.patch('python_anvil.api.GraphqlRequest.post')
         def test_create_etch_packet_valid_dict_type(m_request_post, anvil):
             anvil.create_etch_packet(
                 dict(name="Packet name", signature_email_subject="The subject")


### PR DESCRIPTION
Fixes issue where packets are always created with an `is_test=True` since the `CreateEtchPacket` constructor options were never passed to the final payload creation process.