### PR TITLE
Add forgeSubmit mutation as a client method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.5.0 (2022-08-05)
+
+- Added support for `ForgeSubmit` mutation.
+
 # 1.4.1 (2022-05-11)
 
 - Updated `mkdocs` dependency to fix issue with Read the Docs.

--- a/docs/api_usage.md
+++ b/docs/api_usage.md
@@ -150,6 +150,15 @@ for more details the creation process.
   `CreateEtchPacket` and `CreateEtchPacketPayload`.
 * `json` - Raw JSON payload of the etch packet
 
+### Anvil.forge_submit
+
+Creates an Anvil submission
+object. [See documentation](https://www.useanvil.com/docs/api/graphql/reference/#operation-forgesubmit-Mutations) for
+more details.
+
+* `payload` - Payload to use for the submission. Accepted types are `dict`,
+  `ForgeSubmit` and `ForgeSubmitPayload`.
+* `json` - Raw JSON payload of the `forgeSubmit` mutation.
 
 ### Data Types
 

--- a/examples/create_workflow_submission.py
+++ b/examples/create_workflow_submission.py
@@ -1,0 +1,52 @@
+from python_anvil.api import Anvil
+from datetime import datetime
+from python_anvil.api_resources.payload import ForgeSubmitPayload
+
+API_KEY = 'my-api-key'
+
+
+def main():
+    # Use https://app.useanvil.com/org/YOUR_ORG_HERE/w/WORKFLOW_NAME/api
+    # to get a detailed list and description of which fields, eids, etc.
+    # are available to use.
+    forge_eid = ""
+
+    anvil = Anvil(api_key=API_KEY)
+
+    # Create a payload with the payload model.
+    payload = ForgeSubmitPayload(
+        forge_eid=forge_eid, payload=dict(field1="Initial forgeSubmit")
+    )
+
+    res = anvil.forge_submit(payload=payload)
+
+    data = res["data"]["forgeSubmit"]
+
+    print(data)
+
+    # Get submission and weld_data eids from the initial response
+    submission_eid = data["eid"]
+    weld_data_eid = data["weldData"]["eid"]
+
+    payload = ForgeSubmitPayload(
+        forge_eid=forge_eid,
+        # If submission and weld_data eids are provided, you will be _editing_
+        # an existing submission.
+        submission_eid=submission_eid,
+        weld_data_eid=weld_data_eid,
+        # NOTE: If using a development key, this will `is_test` will always
+        # be `True` even if it's set as `False` here.
+        is_test=False,
+        payload=dict(
+            field1=f"Edited this field {datetime.now()}",
+        ),
+    )
+
+    res = anvil.forge_submit(payload=payload)
+
+    data = res["data"]["forgeSubmit"]
+    print(data)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/create_workflow_submission.py
+++ b/examples/create_workflow_submission.py
@@ -1,6 +1,8 @@
-from python_anvil.api import Anvil
 from datetime import datetime
+
+from python_anvil.api import Anvil
 from python_anvil.api_resources.payload import ForgeSubmitPayload
+
 
 API_KEY = 'my-api-key'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 
 name = "python_anvil"
-version = "1.4.1"
+version = "1.5.0"
 description = "Anvil API"
 
 license = "MIT"

--- a/python_anvil/api.py
+++ b/python_anvil/api.py
@@ -1,12 +1,12 @@
 from logging import getLogger
-from typing import AnyStr, Callable, Dict, List, Optional, Text, Tuple, Union, Any
+from typing import Any, AnyStr, Callable, Dict, List, Optional, Text, Tuple, Union
 
 from .api_resources.mutations import *
 from .api_resources.payload import (
     CreateEtchPacketPayload,
     FillPDFPayload,
-    GeneratePDFPayload,
     ForgeSubmitPayload,
+    GeneratePDFPayload,
 )
 from .api_resources.requests import GraphqlRequest, PlainRequest, RestRequest
 from .http import HTTPClient

--- a/python_anvil/api.py
+++ b/python_anvil/api.py
@@ -1,5 +1,5 @@
 from logging import getLogger
-from typing import AnyStr, Callable, Dict, List, Optional, Tuple, Union
+from typing import AnyStr, Callable, Dict, List, Optional, Text, Tuple, Union
 
 from .api_resources.mutations import *
 from .api_resources.payload import (
@@ -256,8 +256,8 @@ class Anvil:
 
     def forge_submit(
         self,
-        forge_eid: str = None,
-        payload: Optional[Dict[str, any]] = None,
+        forge_eid: Optional[Text] = None,
+        payload: Optional[Dict[Text, Text]] = None,
         json=None,
         **kwargs,
     ):

--- a/python_anvil/api.py
+++ b/python_anvil/api.py
@@ -253,3 +253,35 @@ class Anvil:
         """Retrieve all completed documents in zip form."""
         api = PlainRequest(client=self.client)
         return api.get(f"document-group/{document_group_eid}.zip", **kwargs)
+
+    def forge_submit(
+        self,
+        forge_eid: str = None,
+        payload: Optional[Dict[str, any]] = None,
+        json=None,
+        **kwargs,
+    ):
+        """Create a Webform (forge) submission via a graphql mutation."""
+        if not any([json, payload, forge_eid]):
+            raise TypeError(
+                'Arguments `json` or both `forge_eid` and `payload` are required'
+            )
+
+        mutation = None
+
+        if json:
+            mutation = ForgeSubmit.create_from_json(json)
+
+        if forge_eid and payload:
+            mutation = ForgeSubmit(forge_eid, payload)
+
+        if not mutation:
+            raise ValueError(
+                "`forge_eid` and `payload` are both required if not providing `json`."
+            )
+
+        return self.mutate(
+            mutation,
+            variables=mutation.create_payload().dict(by_alias=True, exclude_none=True),
+            **kwargs,
+        )

--- a/python_anvil/api.py
+++ b/python_anvil/api.py
@@ -210,6 +210,38 @@ class Anvil:
 
         return _get_return(res, get_data=get_data)
 
+    def get_weld(self, eid: Text, **kwargs):
+        res = self.query(
+            """
+            query WeldQuery(
+                #$organizationSlug: String!,
+                #$slug: String!
+                $eid: String!
+            ) {
+                weld(
+                    #organizationSlug: $organizationSlug,
+                    #slug: $slug
+                    eid: $eid
+                ) {
+                    eid
+                    slug
+                    name
+                    forges {
+                        eid
+                        name
+                        slug
+                    }
+                }
+            }""",
+            variables=dict(eid=eid),
+            **kwargs,
+        )
+
+        def get_data(r):
+            return r["data"]["weld"]
+
+        return _get_return(res, get_data=get_data)
+
     def create_etch_packet(
         self,
         payload: Optional[

--- a/python_anvil/api_resources/mutations/__init__.py
+++ b/python_anvil/api_resources/mutations/__init__.py
@@ -1,3 +1,4 @@
 from .base import BaseQuery
 from .create_etch_packet import CreateEtchPacket
 from .generate_etch_signing_url import GenerateEtchSigningURL
+from .forge_submit import ForgeSubmit

--- a/python_anvil/api_resources/mutations/__init__.py
+++ b/python_anvil/api_resources/mutations/__init__.py
@@ -1,4 +1,4 @@
 from .base import BaseQuery
 from .create_etch_packet import CreateEtchPacket
-from .generate_etch_signing_url import GenerateEtchSigningURL
 from .forge_submit import ForgeSubmit
+from .generate_etch_signing_url import GenerateEtchSigningURL

--- a/python_anvil/api_resources/mutations/create_etch_packet.py
+++ b/python_anvil/api_resources/mutations/create_etch_packet.py
@@ -1,5 +1,5 @@
 # pylint: disable=too-many-instance-attributes
-from typing import Any, Dict, List, Optional, Union, TypeVar
+from typing import Any, Dict, List, Optional, Union
 
 from python_anvil.api_resources.mutations.base import BaseQuery
 from python_anvil.api_resources.payload import (
@@ -11,8 +11,6 @@ from python_anvil.api_resources.payload import (
 )
 from python_anvil.utils import create_unique_id
 
-# Create a generic variable that can be 'Parent', or any subclass.
-T = TypeVar("T", bound="Parent")
 
 DEFAULT_RESPONSE_QUERY = """{
   id
@@ -122,7 +120,7 @@ class CreateEtchPacket(BaseQuery):
         self.merge_pdfs = merge_pdfs
 
     @classmethod
-    def create_from_dict(cls, payload: dict) -> T:
+    def create_from_dict(cls, payload: Dict) -> 'CreateEtchPacket':
         """Create a new instance of `CreateEtchPacket` from a dict payload."""
         try:
             mutation = cls(

--- a/python_anvil/api_resources/mutations/create_etch_packet.py
+++ b/python_anvil/api_resources/mutations/create_etch_packet.py
@@ -1,5 +1,5 @@
 # pylint: disable=too-many-instance-attributes
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union, TypeVar
 
 from python_anvil.api_resources.mutations.base import BaseQuery
 from python_anvil.api_resources.payload import (
@@ -11,6 +11,8 @@ from python_anvil.api_resources.payload import (
 )
 from python_anvil.utils import create_unique_id
 
+# Create a generic variable that can be 'Parent', or any subclass.
+T = TypeVar("T", bound="Parent")
 
 DEFAULT_RESPONSE_QUERY = """{
   id
@@ -120,7 +122,7 @@ class CreateEtchPacket(BaseQuery):
         self.merge_pdfs = merge_pdfs
 
     @classmethod
-    def create_from_dict(cls, payload: dict):
+    def create_from_dict(cls, payload: dict) -> T:
         """Create a new instance of `CreateEtchPacket` from a dict payload."""
         try:
             mutation = cls(

--- a/python_anvil/api_resources/mutations/forge_submit.py
+++ b/python_anvil/api_resources/mutations/forge_submit.py
@@ -1,8 +1,9 @@
-from typing import AnyStr, Dict, Text, Any, Union, Optional
+from typing import Any, AnyStr, Dict, Optional, Text, Union
 
 from python_anvil.api_resources.mutations.base import BaseQuery
 from python_anvil.api_resources.mutations.helpers import get_payload_attrs
 from python_anvil.api_resources.payload import ForgeSubmitPayload
+
 
 DEFAULT_RESPONSE_QUERY = """
 {

--- a/python_anvil/api_resources/mutations/forge_submit.py
+++ b/python_anvil/api_resources/mutations/forge_submit.py
@@ -1,0 +1,81 @@
+from typing import Dict
+
+from python_anvil.api_resources.mutations import BaseQuery
+from python_anvil.api_resources.payload import ForgeSubmitPayload
+
+DEFAULT_RESPONSE_QUERY = """
+{
+  id
+  eid
+  payloadValue
+  currentStep
+  completedAt
+  createdAt
+  updatedAt
+  signer {
+    name
+    email
+    status
+    routingOrder
+  }
+  weldData {
+    id
+    eid
+    isTest
+    isComplete
+    agents
+  }
+}
+"""
+
+# NOTE: Since the below will be used as a formatted string (this also applies
+#   to f-strings) any literal curly braces need to be doubled, else they'll be
+#   interpreted as string replacement tokens.
+FORGE_SUBMIT = """
+mutation ForgeSubmit(
+    $forgeEid: String!,
+    $weldDataEid: String,
+    $submissionEid: String,
+    $payload: JSON!,
+    $currentStep: Int,
+    $complete: Boolean,
+    $isTest: Boolean,
+    $timezone: String,
+    $groupArrayId: String,
+    $groupArrayIndex: Int,
+    $errorType: String,
+) {{
+    forgeSubmit (
+        forgeEid: $forgeEid,
+        weldDataEid: $weldDataEid,
+        submissionEid: $submissionEid,
+        payload: $payload,
+        currentStep: $currentStep,
+        complete: $complete,
+        isTest: $isTest,
+        timezone: $timezone,
+        groupArrayId: $groupArrayId,
+        groupArrayIndex: $groupArrayIndex,
+        errorType: $errorType
+    ) {query}
+}}
+"""
+
+
+class ForgeSubmit(BaseQuery):
+    mutation = FORGE_SUBMIT
+    mutation_res_query = DEFAULT_RESPONSE_QUERY
+
+    def __init__(self, forge_eid: str, payload: Dict[any, any]):
+        self.forge_eid = forge_eid
+        self.payload = payload
+
+    @classmethod
+    def create_from_json(cls, json):
+        # Parse the data through the model class to validate and pass it back
+        # as variables in this class.
+        data = ForgeSubmitPayload.parse_raw(json, content_type="application/json")
+        return cls(**data.dict())
+
+    def create_payload(self):
+        return ForgeSubmitPayload(forge_eid=self.forge_eid, payload=self.payload)

--- a/python_anvil/api_resources/mutations/forge_submit.py
+++ b/python_anvil/api_resources/mutations/forge_submit.py
@@ -119,10 +119,8 @@ class ForgeSubmit(BaseQuery):
         model_attrs = get_payload_attrs(ForgeSubmitPayload)
 
         for_payload = {}
-        print(model_attrs)
         for attr in model_attrs:
             obj = getattr(self, attr, None)
-            print(attr, obj)
             if obj is not None:
                 for_payload[attr] = obj
 

--- a/python_anvil/api_resources/mutations/forge_submit.py
+++ b/python_anvil/api_resources/mutations/forge_submit.py
@@ -1,7 +1,8 @@
-from typing import Dict
+from typing import AnyStr, Dict, Text
 
-from python_anvil.api_resources.mutations import BaseQuery
+from python_anvil.api_resources.mutations.base import BaseQuery
 from python_anvil.api_resources.payload import ForgeSubmitPayload
+
 
 DEFAULT_RESPONSE_QUERY = """
 {
@@ -66,12 +67,12 @@ class ForgeSubmit(BaseQuery):
     mutation = FORGE_SUBMIT
     mutation_res_query = DEFAULT_RESPONSE_QUERY
 
-    def __init__(self, forge_eid: str, payload: Dict[any, any]):
+    def __init__(self, forge_eid: Text, payload: Dict[Text, Text]):
         self.forge_eid = forge_eid
         self.payload = payload
 
     @classmethod
-    def create_from_json(cls, json):
+    def create_from_json(cls, json: AnyStr):
         # Parse the data through the model class to validate and pass it back
         # as variables in this class.
         data = ForgeSubmitPayload.parse_raw(json, content_type="application/json")

--- a/python_anvil/api_resources/mutations/forge_submit.py
+++ b/python_anvil/api_resources/mutations/forge_submit.py
@@ -9,7 +9,7 @@ DEFAULT_RESPONSE_QUERY = """
 {
   id
   eid
-  payloadValue
+  resolvedPayload
   currentStep
   completedAt
   createdAt

--- a/python_anvil/api_resources/mutations/forge_submit.py
+++ b/python_anvil/api_resources/mutations/forge_submit.py
@@ -9,6 +9,7 @@ DEFAULT_RESPONSE_QUERY = """
 {
   id
   eid
+  status
   resolvedPayload
   currentStep
   completedAt
@@ -23,6 +24,7 @@ DEFAULT_RESPONSE_QUERY = """
   weldData {
     id
     eid
+    status
     isTest
     isComplete
     agents

--- a/python_anvil/api_resources/mutations/forge_submit.py
+++ b/python_anvil/api_resources/mutations/forge_submit.py
@@ -1,4 +1,4 @@
-from typing import Any, AnyStr, Dict, Optional, Text, Union
+from typing import Any, Dict, Optional, Text, Union
 
 from python_anvil.api_resources.mutations.base import BaseQuery
 from python_anvil.api_resources.mutations.helpers import get_payload_attrs
@@ -108,7 +108,7 @@ class ForgeSubmit(BaseQuery):
     def create_from_dict(cls, payload: Dict[Text, Any]):
         # Parse the data through the model class to validate and pass it back
         # as variables in this class.
-        return cls(**{k: v for k, v in payload.items()})
+        return cls(**payload)
 
     def create_payload(self):
         # If provided a payload and no forge_eid, we'll assume that it's the

--- a/python_anvil/api_resources/mutations/helpers.py
+++ b/python_anvil/api_resources/mutations/helpers.py
@@ -1,6 +1,7 @@
-from typing import List, Text
+from typing import List, Text, Type
+
 from python_anvil.api_resources.base import BaseModel
 
 
-def get_payload_attrs(payload_model: BaseModel) -> List[Text]:
+def get_payload_attrs(payload_model: Type[BaseModel]) -> List[Text]:
     return list(payload_model.__fields__.keys())

--- a/python_anvil/api_resources/mutations/helpers.py
+++ b/python_anvil/api_resources/mutations/helpers.py
@@ -1,0 +1,6 @@
+from typing import List, Text
+from python_anvil.api_resources.base import BaseModel
+
+
+def get_payload_attrs(payload_model: BaseModel) -> List[Text]:
+    return list(payload_model.__fields__.keys())

--- a/python_anvil/api_resources/payload.py
+++ b/python_anvil/api_resources/payload.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Optional, Union
 
 from .base import BaseModel
 
+
 if sys.version_info >= (3, 8):
     from typing import Literal  # pylint: disable=no-name-in-module
 else:

--- a/python_anvil/api_resources/payload.py
+++ b/python_anvil/api_resources/payload.py
@@ -4,8 +4,8 @@ import sys
 
 # Disabling pylint no-name-in-module because this is the documented way to
 # import `BaseModel` and it's not broken, so let's keep it.
-from pydantic import Field, validator, HttpUrl  # pylint: disable=no-name-in-module
-from typing import Any, Dict, List, Optional, Union, Text
+from pydantic import Field, HttpUrl, validator  # pylint: disable=no-name-in-module
+from typing import Any, Dict, List, Optional, Text, Union
 
 from .base import BaseModel
 

--- a/python_anvil/api_resources/payload.py
+++ b/python_anvil/api_resources/payload.py
@@ -4,8 +4,8 @@ import sys
 
 # Disabling pylint no-name-in-module because this is the documented way to
 # import `BaseModel` and it's not broken, so let's keep it.
-from pydantic import Field, validator  # pylint: disable=no-name-in-module
-from typing import Any, Dict, List, Optional, Union
+from pydantic import Field, validator, HttpUrl  # pylint: disable=no-name-in-module
+from typing import Any, Dict, List, Optional, Union, Text
 
 from .base import BaseModel
 
@@ -124,7 +124,8 @@ class CreateEtchFilePayload(BaseModel):
 
 
 class CreateEtchPacketPayload(BaseModel):
-    """Payload for createEtchPacket.
+    """
+    Payload for createEtchPacket.
 
     See the full packet payload defined here:
     https://www.useanvil.com/docs/api/e-signatures#tying-it-all-together
@@ -146,5 +147,25 @@ class CreateEtchPacketPayload(BaseModel):
 
 
 class ForgeSubmitPayload(BaseModel):
-    forge_eid: str
-    payload: Dict[str, Any]
+    """
+    Payload for forgeSubmit.
+
+    See full payload defined here:
+    https://www.useanvil.com/docs/api/graphql/reference/#operation-forgesubmit-Mutations
+    """
+
+    forge_eid: Text
+    payload: Dict[Text, Any]
+    weld_data_eid: Optional[Text] = None
+    submission_eid: Optional[Text] = None
+    # Defaults to True when not provided/is None
+    enforce_payload_valid_on_create: Optional[bool] = None
+    current_step: Optional[int] = None
+    complete: Optional[bool] = None
+    # Note that if using a development API key, this will be forced to `True`
+    # even when `False` is used in the payload.
+    is_test: Optional[bool] = True
+    timezone: Optional[Text] = None
+    webhook_url: Optional[HttpUrl] = Field(None, alias="webhookURL")
+    group_array_id: Optional[Text] = None
+    group_array_index: Optional[int] = None

--- a/python_anvil/api_resources/payload.py
+++ b/python_anvil/api_resources/payload.py
@@ -4,7 +4,12 @@ import sys
 
 # Disabling pylint no-name-in-module because this is the documented way to
 # import `BaseModel` and it's not broken, so let's keep it.
-from pydantic import Field, HttpUrl, validator  # pylint: disable=no-name-in-module
+from pydantic import (  # pylint: disable=no-name-in-module
+    Field,
+    HttpUrl,
+    root_validator,
+    validator,
+)
 from typing import Any, Dict, List, Optional, Text, Union
 
 from .base import BaseModel
@@ -169,3 +174,14 @@ class ForgeSubmitPayload(BaseModel):
     webhook_url: Optional[HttpUrl] = Field(None, alias="webhookURL")
     group_array_id: Optional[Text] = None
     group_array_index: Optional[int] = None
+
+    @root_validator
+    def wd_submission_both_required(cls, values):
+        both_required = ["weld_data_eid", "submission_eid"]
+        picked = [k for k in both_required if k in values and values[k] is not None]
+        if len(picked) == 1:
+            raise ValueError(
+                "Both `weld_data_eid` and `submission_eid` are "
+                "required if either are provided."
+            )
+        return values

--- a/python_anvil/api_resources/payload.py
+++ b/python_anvil/api_resources/payload.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, List, Optional, Union
 
 from .base import BaseModel
 
-
 if sys.version_info >= (3, 8):
     from typing import Literal  # pylint: disable=no-name-in-module
 else:
@@ -143,3 +142,8 @@ class CreateEtchPacketPayload(BaseModel):
     webhook_url: Optional[str] = Field(None, alias="webhookURL")
     reply_to_name: Optional[Any] = None
     reply_to_email: Optional[Any] = None
+
+
+class ForgeSubmitPayload(BaseModel):
+    forge_eid: str
+    payload: Dict[str, Any]

--- a/python_anvil/cli.py
+++ b/python_anvil/cli.py
@@ -103,12 +103,15 @@ def weld(ctx, eid, list_all):
             if debug:
                 click.echo(headers)
 
-        data = [(w["eid"], w.get("slug"), w.get("title")) for w in res]
+        data = [(w["eid"], w.get("slug"), w.get("title"), w.get("forges")) for w in res]
         click.echo(tabulate(data, tablefmt="pretty", headers=["eid", "slug", "title"]))
         return
 
     if not eid:
         raise Exception("You need to pass in a weld eid")
+
+    res = anvil.get_weld(eid)
+    print(res)
 
 
 @cli.command()


### PR DESCRIPTION
Adds a `forge_submit()` method to the client which will allow Webform submissions. 

Usage:
```python
anvil.forge_submit(
    forge_eid="EID_FROM_YOUR_WORKFLOW", 
    payload=dict(
        nameField="My name",
        otherTextField="Some other text"
    )
)

# or with JSON
anvil.forge_submit(json="""{ "forgeEid": "FROM_WORKFLOW", "payload": { "someField": "the data" } }""")
```


TODO:
- [x] Add forgeSubmit update(?) support
- [x] Add example
- [x] Add docs
- [x] Maybe easy way to get forge EIDs via CLI? 
