### PR TITLE
Support HTML/CSS in createEtchPacket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.5.0 (2022-09-07)
+
+- Added support for HTML/CSS and Markdown in `CreateEtchPacket`. [See examples here](https://www.useanvil.com/docs/api/e-signatures#generating-a-pdf-from-html-and-css).
+
 # 1.5.0 (2022-08-05)
 
 - Added support for `ForgeSubmit` mutation.

--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ General API documentation: [Anvil API docs](https://www.useanvil.com/docs)
 
 Install it directly into an activated virtual environment:
 
-```text
+```shell
 $ pip install python-anvil
 ```
 
 or add it to your [Poetry](https://python-poetry.org/) project:
 
-```text
+```shell
 $ poetry add python-anvil
 ```

--- a/docs/api_usage.md
+++ b/docs/api_usage.md
@@ -3,7 +3,7 @@
 All methods assume that a valid API key is already available. Please take a look
 at [Anvil API Basics](https://www.useanvil.com/docs/api/basics) for more details on how to get your key.
 
-### Anvil() constructor
+### `Anvil` constructor
 
 * `api_key` - Your Anvil API key, either development or production
 * `environment` (default: `'dev'`) - The type of key being used. This affects how the library sets rate limits on API

--- a/examples/create_etch_markdown.py
+++ b/examples/create_etch_markdown.py
@@ -3,8 +3,9 @@
 from python_anvil.api import Anvil
 from python_anvil.api_resources.mutations.create_etch_packet import CreateEtchPacket
 from python_anvil.api_resources.payload import (
-    DocumentMarkup,
+    DocumentMarkdown,
     EtchSigner,
+    MarkdownContent,
     SignatureField,
     SignerField,
 )
@@ -48,31 +49,31 @@ def main():
     # For this example, a PDF will not be uploaded. We'll create and style the
     # document with HTML and CSS and add signing fields based on coordinates.
 
-    # Define the document with HTML/CSS
-    file1 = DocumentMarkup(
-        id="myNewFile",
-        title="Please sign this important form",
-        filename="markup.pdf",
-        markup={
-            "html": """
-                <div class="first">This document is created with HTML.</div>
-                <br />
-                <br />
-                <br />
-                <div>We can also define signing fields with text tags</div>
-                <div>{{ signature : First signature : textTag : textTag }}</div>
-            """,
-            "css": """"body{ color: red; }  div.first { color: blue; } """,
-        },
+    # Define the document with Markdown
+    file1 = DocumentMarkdown(
+        id="markdownFile",
+        filename="markdown.pdf",
+        title="Sign this markdown file",
         fields=[
+            # This is markdown content
+            MarkdownContent(
+                table=dict(
+                    rows=[
+                        ['Description', 'Quantity', 'Price'],
+                        ['3x Roof Shingles', '15', '$60.00'],
+                        ['5x Hardwood Plywood', '10', '$300.00'],
+                        ['80x Wood Screws', '80', '$45.00'],
+                    ],
+                )
+            ),
             SignatureField(
+                page_num=0,
                 id="sign1",
                 type="signature",
-                page_num=0,
                 # The position and size of the field. The coordinates provided here
                 # (x=300, y=300) is the top-left of the rectangle.
                 rect=dict(x=300, y=300, width=250, height=30),
-            )
+            ),
         ],
     )
 
@@ -89,15 +90,9 @@ def main():
         fields=[
             SignerField(
                 # this is the `id` in the `DocumentUpload` object above
-                file_id="myNewFile",
+                file_id="markdownFile",
                 # This is the signing field id in the `SignatureField` above
                 field_id="sign1",
-            ),
-            SignerField(
-                # this is the `id` in the `DocumentUpload` object above
-                file_id="myNewFile",
-                # This is the signing field id in the `SignatureField` above
-                field_id="textTag",
             ),
         ],
         signer_type="embedded",

--- a/examples/create_etch_markup.py
+++ b/examples/create_etch_markup.py
@@ -1,0 +1,142 @@
+# pylint: disable=duplicate-code
+
+from python_anvil.api import Anvil
+from python_anvil.api_resources.mutations.create_etch_packet import CreateEtchPacket
+from python_anvil.api_resources.payload import (
+    DocumentMarkup,
+    EtchSigner,
+    SignatureField,
+    SignerField,
+)
+
+
+API_KEY = 'my-api-key'
+
+
+def main():
+    anvil = Anvil(api_key=API_KEY)
+
+    # Create an instance of the builder
+    packet = CreateEtchPacket(
+        name="Etch packet with existing template",
+        #
+        # Optional changes to email subject and body content
+        signature_email_subject="Please sign these forms",
+        signature_email_body="This form requires information from your driver's "
+        "license. Please have that available.",
+        #
+        # URL where Anvil will send POST requests when server events happen.
+        # Take a look at https://www.useanvil.com/docs/api/e-signatures#webhook-notifications
+        # for other details on how to configure webhooks on your account.
+        # You can also use sites like webhook.site, requestbin.com or ngrok to
+        # test webhooks.
+        # webhook_url="https://my.webhook.example.com/etch-events/",
+        #
+        # Email overrides for the "reply-to" email header for signer emails.
+        # If used, both `reply_to_email` and `reply_to_name` are required.
+        # By default, this will point to your organization support email.
+        # reply_to_email="my-org-email@example.com",
+        # reply_to_name="My Name",
+        #
+        # Merge all PDFs into one. Use this if you have many PDF templates
+        # and/or files, but want the final downloaded package to be only
+        # 1 PDF file.
+        # merge_pdfs=True,
+    )
+
+    # Get your file(s) ready to sign.
+    # For this example, a PDF will not be uploaded. We'll create and style the
+    # document with HTML and CSS and add signing fields based on coordinates.
+
+    # Define the document with HTML/CSS
+    file1 = DocumentMarkup(
+        id="myNewFile",
+        title="Please sign this important form",
+        filename="markup.pdf",
+        markup={
+            "html": """
+                <div class="first">This document is created with HTML.</div>
+                <br />
+                <br />
+                <br />
+                <div>We can also define signing fields with text tags</div>
+                <div>{{ signature : First signature : textTag : textTag }}</div>
+            """,
+            "css": """"body{ color: red; }  div.first { color: blue; } """,
+        },
+        fields=[
+            SignatureField(
+                id="sign1",
+                type="signature",
+                page_num=0,
+                # The position and size of the field. The coordinates provided here
+                # (x=100, y=100) is the top-left of the rectangle.
+                rect=dict(x=10, y=10, width=250, height=50),
+            )
+        ],
+    )
+
+    # Gather your signer data
+    signer1 = EtchSigner(
+        name="Jackie",
+        email="jackie@example.com",
+        # Fields where the signer needs to sign.
+        # Check your cast fields via the CLI (`anvil cast [cast_eid]`) or the
+        # PDF Templates section on the Anvil app.
+        # This basically says: "In the 'myNewFile' file (defined in
+        # `file1` above), assign the signature field with cast id of
+        # 'sign1' to this signer." You can add multiple signer fields here.
+        fields=[
+            SignerField(
+                # this is the `id` in the `DocumentUpload` object above
+                file_id="myNewFile",
+                # This is the signing field id in the `SignatureField` above
+                field_id="sign1",
+            ),
+            SignerField(
+                # this is the `id` in the `DocumentUpload` object above
+                file_id="myNewFile",
+                # This is the signing field id in the `SignatureField` above
+                field_id="textTag",
+            ),
+        ],
+        signer_type="embedded",
+        #
+        # You can also change how signatures will be collected.
+        # "draw" will allow the signer to draw their signature
+        # "text" will insert a text version of the signer's name into the
+        # signature field.
+        # signature_mode="draw",
+        #
+        # Whether or not to the signer is required to click each signature
+        # field manually. If `False`, the PDF will be signed once the signer
+        # accepts the PDF without making the user go through the PDF.
+        # accept_each_field=False,
+        #
+        # URL of where the signer will be redirected after signing.
+        # The URL will also have certain URL params added on, so the page
+        # can be customized based on the signing action.
+        # redirect_url="https://www.google.com",
+    )
+
+    # Add your signer.
+    packet.add_signer(signer1)
+
+    # Add files to your payload
+    packet.add_file(file1)
+
+    # If needed, you can also override or add additional payload fields this way.
+    # This is useful if the Anvil API has new features, but `python-anvil` has not
+    # yet been updated to support it.
+    # payload = packet.create_payload()
+    # payload.aNewFeature = True
+
+    # Create your packet
+    # If overriding/adding new fields, use the modified payload from
+    # `packet.create_payload()`
+    res = anvil.create_etch_packet(payload=packet, include_headers=True)
+    print(res)
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/generate_pdf.py
+++ b/examples/generate_pdf.py
@@ -1,0 +1,26 @@
+from python_anvil.api import Anvil
+from python_anvil.api_resources.payload import GeneratePDFPayload
+
+
+API_KEY = 'my-api-key'
+
+
+def main():
+    anvil = Anvil(api_key=API_KEY)
+    data = GeneratePDFPayload(
+        type="html",
+        title="Some Title",
+        data=dict(
+            html="<h2>HTML Heading</h2>",
+            css="h2 { color: red }",
+        ),
+    )
+    response = anvil.generate_pdf(data)
+
+    # Write the bytes to disk
+    with open('./generated.pdf', 'wb') as f:
+        f.write(response)
+
+
+if __name__ == '__main__':
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 
 name = "python_anvil"
-version = "1.5.0"
+version = "1.6.0"
 description = "Anvil API"
 
 license = "MIT"

--- a/python_anvil/api.py
+++ b/python_anvil/api.py
@@ -93,7 +93,7 @@ class Anvil:
             **kwargs,
         )
 
-    def generate_pdf(self, payload: Union[AnyStr, Dict], **kwargs):
+    def generate_pdf(self, payload: Union[AnyStr, Dict, GeneratePDFPayload], **kwargs):
         if not payload:
             raise ValueError("`payload` must be a valid JSON string or a dict")
 
@@ -103,10 +103,12 @@ class Anvil:
             data = GeneratePDFPayload.parse_raw(
                 payload, content_type="application/json"
             )
+        elif isinstance(payload, GeneratePDFPayload):
+            data = payload
         else:
             raise ValueError("`payload` must be a valid JSON string or a dict")
 
-        # Any data errors would come from here..
+        # Any data errors would come from here
         api = RestRequest(client=self.client)
         return api.post(
             "generate-pdf", data=data.dict(by_alias=True, exclude_none=True), **kwargs

--- a/python_anvil/api_resources/mutations/create_etch_packet.py
+++ b/python_anvil/api_resources/mutations/create_etch_packet.py
@@ -5,6 +5,7 @@ from python_anvil.api_resources.mutations.base import BaseQuery
 from python_anvil.api_resources.payload import (
     CreateEtchFilePayload,
     CreateEtchPacketPayload,
+    DocumentMarkup,
     DocumentUpload,
     EtchCastRef,
     EtchSigner,
@@ -86,7 +87,9 @@ class CreateEtchPacket(BaseQuery):
         signature_email_subject: Optional[str] = None,
         signature_email_body: Optional[str] = None,
         signers: Optional[List[EtchSigner]] = None,
-        files: Optional[List[Union[DocumentUpload, EtchCastRef]]] = None,
+        files: Optional[
+            List[Union[DocumentUpload, EtchCastRef, DocumentMarkup]]
+        ] = None,
         file_payloads: Optional[dict] = None,
         signature_page_options: Optional[Dict[Any, Any]] = None,
         is_draft: bool = False,
@@ -172,7 +175,7 @@ class CreateEtchPacket(BaseQuery):
 
         self.signers.append(data)
 
-    def add_file(self, file: Union[DocumentUpload, EtchCastRef]):
+    def add_file(self, file: Union[DocumentUpload, EtchCastRef, DocumentMarkup]):
         """Add file to a pending list of Upload objects.
 
         Files will not be uploaded when running this method. The will be

--- a/python_anvil/api_resources/mutations/create_etch_packet.py
+++ b/python_anvil/api_resources/mutations/create_etch_packet.py
@@ -5,6 +5,7 @@ from python_anvil.api_resources.mutations.base import BaseQuery
 from python_anvil.api_resources.payload import (
     CreateEtchFilePayload,
     CreateEtchPacketPayload,
+    DocumentMarkdown,
     DocumentMarkup,
     DocumentUpload,
     EtchCastRef,
@@ -88,7 +89,7 @@ class CreateEtchPacket(BaseQuery):
         signature_email_body: Optional[str] = None,
         signers: Optional[List[EtchSigner]] = None,
         files: Optional[
-            List[Union[DocumentUpload, EtchCastRef, DocumentMarkup]]
+            List[Union[DocumentUpload, EtchCastRef, DocumentMarkup, DocumentMarkdown]]
         ] = None,
         file_payloads: Optional[dict] = None,
         signature_page_options: Optional[Dict[Any, Any]] = None,
@@ -175,7 +176,9 @@ class CreateEtchPacket(BaseQuery):
 
         self.signers.append(data)
 
-    def add_file(self, file: Union[DocumentUpload, EtchCastRef, DocumentMarkup]):
+    def add_file(
+        self, file: Union[DocumentUpload, EtchCastRef, DocumentMarkup, DocumentMarkdown]
+    ):
         """Add file to a pending list of Upload objects.
 
         Files will not be uploaded when running this method. The will be

--- a/python_anvil/api_resources/mutations/forge_submit.py
+++ b/python_anvil/api_resources/mutations/forge_submit.py
@@ -80,6 +80,8 @@ class ForgeSubmit(BaseQuery):
         **kwargs,
     ):
         """
+        Create a forgeSubmit query.
+
         :param forge_eid:
         :param payload:
         :param weld_data_eid:

--- a/python_anvil/api_resources/payload.py
+++ b/python_anvil/api_resources/payload.py
@@ -105,14 +105,74 @@ class Base64Upload(BaseModel):
     mimetype: str = "application/pdf"
 
 
+class TableColumnAlignment(BaseModel):
+    align: Optional[Literal["left", "center", "right"]] = None
+    width: Optional[str] = None
+
+
+# https://www.useanvil.com/docs/api/generate-pdf#table
+class MarkdownTable(BaseModel):
+    rows: List[List[str]]
+
+    # defaults to `True` if not provided.
+    # set to false for no header row on the table
+    first_row_headers: Optional[bool] = None
+
+    # defaults to `False` if not provided.
+    # set to true to display gridlines in-between rows or columns
+    row_grid_lines: Optional[bool] = True
+    column_grid_lines: Optional[bool] = False
+
+    # defaults to 'top' if not provided.
+    # adjust vertical alignment of table text
+    # accepts 'top', 'center', or 'bottom'
+    vertical_align: Optional[Literal["top", "center", "bottom"]] = "center"
+
+    # (optional) columnOptions - An array of columnOption objects.
+    # You do not need to specify all columns. Accepts an
+    # empty object indicating no overrides on the
+    # specified column.
+    #
+    # Supported keys for columnOption:
+    # align (optional) - adjust horizontal alignment of table text
+    # accepts 'left', 'center', or 'right'; defaults to 'left'
+    # width (optional) - adjust the width of the column
+    # accepts width in pixels or as percentage of the table width
+    column_options: Optional[List[TableColumnAlignment]] = None
+
+
+# https://www.useanvil.com/docs/api/object-references/#verbatimfield
+class MarkdownContent(BaseModel):
+    label: Optional[str] = None
+    heading: Optional[str] = None
+    content: Optional[str] = None
+    table: Optional[MarkdownTable] = None
+    font_size: int = 14
+    text_color: str = "#000000"
+
+
 class DocumentMarkup(BaseModel):
     """Dataclass representing a document with HTML/CSS markup."""
 
     id: str
-    title: str
     filename: str
     markup: Dict[Literal["html", "css"], str]
     fields: Optional[List[SignatureField]] = None
+    title: Optional[str] = None
+    font_size: int = 14
+    text_color: str = "#000000"
+
+
+class DocumentMarkdown(BaseModel):
+    """Dataclass representing a document with Markdown."""
+
+    id: str
+    filename: str
+    # NOTE: Order matters here in the Union[].
+    # If `SignatureField` is not first, the types are similar enough that it
+    # will use `MarkdownContent` instead.
+    fields: Optional[List[Union[SignatureField, MarkdownContent]]] = None
+    title: Optional[str] = None
     font_size: int = 14
     text_color: str = "#000000"
 
@@ -150,7 +210,7 @@ class CreateEtchPacketPayload(BaseModel):
 
     name: str
     signers: List[EtchSigner]
-    files: List[Union[DocumentUpload, EtchCastRef, DocumentMarkup]]
+    files: List[Union[DocumentUpload, EtchCastRef, DocumentMarkup, DocumentMarkdown]]
     signature_email_subject: Optional[str] = None
     signature_email_body: Optional[str] = None
     is_draft: Optional[bool] = False

--- a/python_anvil/api_resources/payload.py
+++ b/python_anvil/api_resources/payload.py
@@ -105,6 +105,18 @@ class Base64Upload(BaseModel):
     mimetype: str = "application/pdf"
 
 
+class DocumentMarkup(BaseModel):
+    """Dataclass representing a document with HTML/CSS markup."""
+
+    id: str
+    title: str
+    filename: str
+    markup: Dict[Literal["html", "css"], str]
+    fields: Optional[List[SignatureField]] = None
+    font_size: int = 14
+    text_color: str = "#000000"
+
+
 class DocumentUpload(BaseModel):
     """Dataclass representing an uploaded document."""
 
@@ -138,7 +150,7 @@ class CreateEtchPacketPayload(BaseModel):
 
     name: str
     signers: List[EtchSigner]
-    files: List[Union[DocumentUpload, EtchCastRef]]
+    files: List[Union[DocumentUpload, EtchCastRef, DocumentMarkup]]
     signature_email_subject: Optional[str] = None
     signature_email_body: Optional[str] = None
     is_draft: Optional[bool] = False


### PR DESCRIPTION
Adds ability to use HTML/CSS instead of uploading/using an existing document on the `createEtchPacket` mutation. 