### PR TITLE
Remove unnecessary file length calculation in FileCompatibleBaseModel and Debug Code

### DIFF
--- a/python_anvil/api.py
+++ b/python_anvil/api.py
@@ -392,23 +392,7 @@ class Anvil:
             )
 
         payload = mutation.create_payload()
-
-        # FIXME: do something here to prevent or fix pydantic from converting
-        # files into "SerializationIterator" objects
         variables = payload.model_dump(by_alias=True, exclude_none=True)
-
-        # print('Files', variables["files"])
-        # print('Each')
-        for file_obj in variables["files"]:
-            if (
-                file_obj["file"]
-                and file_obj["file"].__class__.__name__ == 'SerializationIterator'
-            ):
-                # print("FML1", file_obj["file"])
-                # print("FML2", dir(file_obj["file"]))
-
-                # TODO: how to get the value out of the iterator??????????
-                file_obj["file"] = file_obj["file"]
 
         return self.mutate(mutation, variables=variables, upload_files=True, **kwargs)
 

--- a/python_anvil/models.py
+++ b/python_anvil/models.py
@@ -29,15 +29,8 @@ class FileCompatibleBaseModel(BaseModel):
         except StopIteration:
             # Create a BytesIO with the content
             bio = BytesIO(bytes(content))
-            # Get the total length
-            bio.seek(0, 2)  # Seek to end
-            total_length = bio.tell()
-            bio.seek(0)  # Reset to start
-
             # Create a BufferedReader with the content
             reader = BufferedReader(bio)  # type: ignore[arg-type]
-            # Add a length attribute that requests_toolbelt can use
-            reader.len = total_length  # type: ignore[attr-defined]
             return reader
 
     def _check_if_serialization_iterator(self, value):


### PR DESCRIPTION
## Description
This PR simplifies the `_iterator_to_buffered_reader` method in `FileCompatibleBaseModel` by removing unneeded file length calculation logic. The `len` attribute was previously added for `requests_toolbelt` compatibility, but testing shows it's not required for the current implementation.

### Changes
- Removed `seek()` operations used for length calculation
- Removed setting of custom `len` attribute on the `BufferedReader`
- Simplified the buffer creation process
- Removed test code from api.py from original branch `bo/upgrade`

### Before
```python
bio.seek(0, 2)  # Seek to end
total_length = bio.tell()
bio.seek(0)  # Reset to start
reader = BufferedReader(bio)
reader.len = total_length  # type: ignore[attr-defined]
```

### After
```python
reader = BufferedReader(bio)
```

### Testing
✅ All existing tests pass  
✅ File upload functionality continues to work as expected

### Why
The removed code was adding complexity without providing any benefit to the current implementation. The `requests_toolbelt` library doesn't require the length attribute for proper functioning in our use case.
