### PR TITLE
chore: get isort and black on the same page

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -12,3 +12,5 @@ include_trailing_comma = true
 
 lines_after_imports = 2
 line_length = 88
+
+profile = black


### PR DESCRIPTION
just getting `isort` and `black` on the same page