### PR TITLE
Improvement: support full absolute URLs without base path joining (closes #79)

### DIFF
--- a/python_anvil/api_resources/requests.py
+++ b/python_anvil/api_resources/requests.py
@@ -20,7 +20,11 @@ class AnvilRequest:
         if method.upper() not in ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]:
             raise ValueError("Invalid HTTP method provided")
 
-        full_url = "/".join([self.get_url(), url]) if len(url) > 0 else self.get_url()
+        absolute_url = kwargs.pop("absolute_url", False)
+        if absolute_url:
+            full_url = url
+        else:
+            full_url = "/".join([self.get_url(), url]) if len(url) > 0 else self.get_url()
 
         return self._client.request(method, full_url, **kwargs)
 
@@ -64,16 +68,18 @@ class BaseAnvilHttpRequest(AnvilRequest):
 
     def get(self, url, params=None, **kwargs):
         retry = kwargs.pop("retry", True)
+        absolute_url = kwargs.pop("absolute_url", False)
         content, status_code, headers = self._request(
-            "GET", url, params=params, retry=retry
+            "GET", url, params=params, retry=retry, absolute_url=absolute_url
         )
         return self.process_response(content, status_code, headers, **kwargs)
 
     def post(self, url, data=None, **kwargs):
         retry = kwargs.pop("retry", True)
+        absolute_url = kwargs.pop("absolute_url", False)
         params = kwargs.pop("params", None)
         content, status_code, headers = self._request(
-            "POST", url, json=data, retry=retry, params=params
+            "POST", url, json=data, retry=retry, params=params, absolute_url=absolute_url
         )
         return self.process_response(content, status_code, headers, **kwargs)
 

--- a/python_anvil/tests/test_api.py
+++ b/python_anvil/tests/test_api.py
@@ -396,3 +396,55 @@ def describe_api():
             anvil.forge_submit(payload=payload)
             assert m_request_post.call_count == 1
             assert _expected_data in m_request_post.call_args
+
+    def describe_rest_request_absolute_url_behavior():
+        @pytest.mark.parametrize(
+            "url, expected_absolute_url",
+            [
+                ("some/relative/path", False),
+                ("https://external.example.com/full/path/file.pdf", True),
+            ],
+        )
+        @mock.patch("python_anvil.api_resources.requests.AnvilRequest._request")
+        def test_get_behavior(mock_request, anvil, url, expected_absolute_url):
+            mock_request.return_value = (b"fake_content", 200, {})
+            rest_client = anvil.request_rest()
+
+            if expected_absolute_url:
+                rest_client.get(url, absolute_url=True)
+            else:
+                rest_client.get(url)
+
+            mock_request.assert_called_once_with(
+                "GET",
+                url,
+                params=None,
+                retry=True,
+                absolute_url=expected_absolute_url,
+            )
+
+        @pytest.mark.parametrize(
+            "url, expected_absolute_url",
+            [
+                ("some/relative/path", False),
+                ("https://external.example.com/full/path/file.pdf", True),
+            ],
+        )
+        @mock.patch("python_anvil.api_resources.requests.AnvilRequest._request")
+        def test_post_behavior(mock_request, anvil, url, expected_absolute_url):
+            mock_request.return_value = (b"fake_content", 200, {})
+            rest_client = anvil.request_rest()
+
+            if expected_absolute_url:
+                rest_client.post(url, data={}, absolute_url=True)
+            else:
+                rest_client.post(url, data={})
+
+            mock_request.assert_called_once_with(
+                "POST",
+                url,
+                json={},
+                retry=True,
+                params=None,
+                absolute_url=expected_absolute_url,
+            )


### PR DESCRIPTION
Closes #79

# Description
This PR addresses Issue #79 where passing a fully-qualified URL to request_rest.get() or request_rest.post() would incorrectly prepend the base URL, resulting in an invalid request.

# Changes

- Added absolute_url option to BaseAnvilHttpRequest.get() and post() methods.
- Updated _request method to respect absolute_url flag.
- Tests for get and post that verify both relative paths and absolute URLs are handled correctly.