### PR TITLE
Add .anvil/marketing.yml for marketing-site language pages

### DIFF
--- a/.anvil/marketing.yml
+++ b/.anvil/marketing.yml
@@ -1,12 +1,5 @@
-products:
-  - generate
-  - fill
-  - sign
-packageManagerInstall: pip install python-anvil
+packageManagerInstall:
+  - pip install python-anvil
 languages:
   - key: python
     label: Python
-    examples:
-      generate: examples/generate_pdf.py
-      fill: examples/fill_pdf.py
-      sign: examples/create_etch_existing_cast.py

--- a/.anvil/marketing.yml
+++ b/.anvil/marketing.yml
@@ -1,6 +1,3 @@
-# Language declaration for anvilco/marketing-site. Read at build time to source
-# the Python SDK page from this repo. `supported` is omitted so it derives from
-# repo visibility (public = live).
 products:
   - generate
   - fill
@@ -9,7 +6,6 @@ packageManagerInstall: pip install python-anvil
 languages:
   - key: python
     label: Python
-    slug: python
     examples:
       generate: examples/generate_pdf.py
       fill: examples/fill_pdf.py

--- a/.anvil/marketing.yml
+++ b/.anvil/marketing.yml
@@ -1,0 +1,16 @@
+# Language declaration for anvilco/marketing-site. Read at build time to source
+# the Python SDK page from this repo. `supported` is omitted so it derives from
+# repo visibility (public = live).
+products:
+  - generate
+  - fill
+  - sign
+packageManagerInstall: pip install python-anvil
+languages:
+  - key: python
+    label: Python
+    slug: python
+    examples:
+      generate: examples/generate_pdf.py
+      fill: examples/fill_pdf.py
+      sign: examples/create_etch_existing_cast.py


### PR DESCRIPTION
Adds `.anvil/marketing.yml` so anvilco/marketing-site sources this repo's Python SDK page at build time (language identity, install command, products, and per-product example paths) instead of hardcoding them in the marketing site.

`supported` is omitted so the marketing site derives live/coming-soon from this repo's visibility. The example paths point at `examples/generate_pdf.py`, `examples/fill_pdf.py`, and `examples/create_etch_existing_cast.py`.

Related to anvilco/marketing-site#3505.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/anvilco/codesmith/python-anvil/pr/89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788559158&installation_model_id=8728&pr_number=89&repository=anvilco%2Fpython-anvil&return_to=https%3A%2F%2Fgithub.com%2Fanvilco%2Fpython-anvil%2Fpull%2F89&signature=9aaaeb17812e3ad88c4b7dda6c405601afcbf0761086c950b8edd17455f4a943"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->